### PR TITLE
[#12] refact : target market code parameter refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,15 @@ const {isLoading, marketCodes} = useFetchMarketCode(
 );
 ```
 
-## CAUTIONs IN HOOKS
+---
 
-⚠️ targetMarketCode should be state in react (useState, ...), if not, unexpectable error can occur.
+## ⚠️ CAUTIONs IN WEBSOCKET API
+
+targetMarketCode should be state in react (useState, ...), if not, unexpectable error can occur.
+
+Do not use just constant or variable.
+
+---
 
 ## useWsTicker
 
@@ -71,6 +77,7 @@ const [targetMarketCode, _] = useState([
 
 const {socket, isConnected, socketData} = useWsTicker(
   targetMarketCode, // should be array
+  onError, // onError?: (error: Error) => void // optional, user for using ErrorBoundary
   (options = {throttle_time: 400, debug: false}), // default option, can be modified.
 );
 ```
@@ -88,6 +95,7 @@ const [targetMarketCode, _] = useState({
 
 const {socket, isConnected, socketData} = useWsOrderbook(
   targetMarketCode, // should be above form object
+  onError, // onError?: (error: Error) => void // optional, user for using ErrorBoundary
   (options = {throttle_time: 400, debug: false}), // default option, can be modified.
 );
 ```
@@ -106,9 +114,12 @@ const [targetMarketCode, _] = useState({
 
 const {socket, isConnected, socketData} = useWsTrade(
   targetMarketCode, // should be above form object
+  onError, // onError?: (error: Error) => void // optional, user for using ErrorBoundary
   (options = {throttle_time: 400, max_length_queue: 100, debug: false}), // default option, can be modified.
 );
 ```
+
+---
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -51,13 +51,26 @@ const {isLoading, marketCodes} = useFetchMarketCode(
 );
 ```
 
+## CAUTIONs IN HOOKS
+
+⚠️ targetMarketCode should be state in react (useState, ...), if not, unexpectable error can occur.
+
 ## useWsTicker
 
 useWsTicker is a custom hook that connects to a WebSocket API and retrieves real-time ticker data for a given market code.
 
 ```tsx
+const [targetMarketCode, _] = useState([
+  {
+    market: 'KRW-BTC',
+    korean_name: '비트코인',
+    english_name: 'Bitcoin',
+  },
+  ...
+]);
+
 const {socket, isConnected, socketData} = useWsTicker(
-  targetMarketCode,
+  targetMarketCode, // should be array
   (options = {throttle_time: 400, debug: false}), // default option, can be modified.
 );
 ```
@@ -67,8 +80,14 @@ const {socket, isConnected, socketData} = useWsTicker(
 useWsOrderbook is a custom hook that connects to a WebSocket API and retrieves real-time order book data for a given market code.
 
 ```tsx
+const [targetMarketCode, _] = useState({
+  market: 'KRW-BTC',
+  korean_name: '비트코인',
+  english_name: 'Bitcoin',
+});
+
 const {socket, isConnected, socketData} = useWsOrderbook(
-  targetMarketCode,
+  targetMarketCode, // should be above form object
   (options = {throttle_time: 400, debug: false}), // default option, can be modified.
 );
 ```
@@ -79,8 +98,14 @@ useWsTrade is a custom hook that connects to a WebSocket API
 and retrieves real-time trade data for a given market code.
 
 ```tsx
+const [targetMarketCode, _] = useState({
+  market: 'KRW-BTC',
+  korean_name: '비트코인',
+  english_name: 'Bitcoin',
+});
+
 const {socket, isConnected, socketData} = useWsTrade(
-  targetMarketCode,
+  targetMarketCode, // should be above form object
   (options = {throttle_time: 400, max_length_queue: 100, debug: false}), // default option, can be modified.
 );
 ```
@@ -90,17 +115,15 @@ const {socket, isConnected, socketData} = useWsTrade(
 Thank you for your interest in contributing to use-upbit-api. Before you begin writing code, it is important that you share your intention to contribute with the team, based on the type of contribution
 
 1. You want to **propose a new feature** and implement it.
-    - Post about your intended feature in an [issue](https://github.com/devKangMinHyeok/use-upbit-api/issues), then implement it.
-    - We suggest that the branch name that you implement is better to be {type}/{issue number}/{issue name}. ex) feature/118/githubAction, bugfix/120/typo
-    
+   - Post about your intended feature in an [issue](https://github.com/devKangMinHyeok/use-upbit-api/issues), then implement it.
+   - We suggest that the branch name that you implement is better to be {type}/{issue number}/{issue name}. ex) feature/118/githubAction, bugfix/120/typo
 2. You want to **implement a feature or bug-fix** for an outstanding issue.
-    - Search for your issue in the [Mips-simulator-js issue list](https://github.com/devKangMinHyeok/use-upbit-api/issues).
-    - Pick an issue and comment that you'd like to work on the feature or bug-fix.
-    - If you need more context on a particular issue, please ask and we shall provide.
-    
+   - Search for your issue in the [Mips-simulator-js issue list](https://github.com/devKangMinHyeok/use-upbit-api/issues).
+   - Pick an issue and comment that you'd like to work on the feature or bug-fix.
+   - If you need more context on a particular issue, please ask and we shall provide.
 3. **Open pull request**
-    - You implement and test your feature or bug-fix, please submit a Pull Request to [https://github.com/mipsSimulatorUNIST/simulator/pulls](https://github.com/devKangMinHyeok/use-upbit-api/pulls) with some test case.
-    - Once a pull request is accepted and CI is passing, there is nothing else you need to do. we will check and merge the PR for you.
+   - You implement and test your feature or bug-fix, please submit a Pull Request to [https://github.com/mipsSimulatorUNIST/simulator/pulls](https://github.com/devKangMinHyeok/use-upbit-api/pulls) with some test case.
+   - Once a pull request is accepted and CI is passing, there is nothing else you need to do. we will check and merge the PR for you.
 
 **_Always opening_** to join this project for developing this library.
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,9 @@
 
 ![TOTALEXAMPLE](https://user-images.githubusercontent.com/44657722/183570075-cb54905c-a57c-44a6-96c3-3d66dccef054.gif)
 
----
-
 ## Install
 
     npm install --save use-upbit-api
-
----
 
 ## Hooks
 
@@ -39,8 +35,6 @@
 
 [useWsTrade](#usewstrade)
 
----
-
 ## useFetchMarketCode
 
 useFetchMarketCode hook is used to fetch market codes from upbit api
@@ -51,15 +45,11 @@ const {isLoading, marketCodes} = useFetchMarketCode(
 );
 ```
 
----
-
 ## ⚠️ CAUTIONs IN WEBSOCKET API
 
 targetMarketCode should be state in react (useState, ...), if not, unexpectable error can occur.
 
 Do not use just constant or variable.
-
----
 
 ## useWsTicker
 
@@ -118,8 +108,6 @@ const {socket, isConnected, socketData} = useWsTrade(
   (options = {throttle_time: 400, max_length_queue: 100, debug: false}), // default option, can be modified.
 );
 ```
-
----
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "use-upbit-api",
-  "version": "1.1.5",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "use-upbit-api",
-      "version": "1.1.5",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.20.2",
@@ -32,6 +32,8 @@
         "jest-environment-jsdom": "^29.5.0",
         "jest-fetch-mock": "^3.0.3",
         "prettier": "^2.8.7",
+        "react": ">=17.0.2",
+        "react-dom": ">=17.0.2",
         "ts-jest": "^29.0.5",
         "typescript": "^5.0.2"
       },
@@ -6449,7 +6451,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -6663,7 +6666,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -6900,7 +6903,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7371,7 +7374,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -7384,7 +7387,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -7684,7 +7687,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -13274,7 +13277,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -13443,7 +13447,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -13623,7 +13627,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "peer": true
+      "dev": true
     },
     "object-inspect": {
       "version": "1.12.3",
@@ -13942,7 +13946,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -13952,7 +13956,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -14168,7 +14172,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-upbit-api",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "This is React Custom Hook for upbit api",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/functions/isArrayOfImarketCodes.ts
+++ b/src/functions/isArrayOfImarketCodes.ts
@@ -1,0 +1,10 @@
+import {ImarketCodes} from '../interfaces';
+import isImarketCodes from './isImarketCodes';
+
+const isArrayOfImarketCodes = (obj: unknown): obj is ImarketCodes[] => {
+  if (!Array.isArray(obj) || obj.length === 0) return false;
+
+  return obj.every(item => isImarketCodes(item));
+};
+
+export default isArrayOfImarketCodes;

--- a/src/functions/isImarketCodes.ts
+++ b/src/functions/isImarketCodes.ts
@@ -1,0 +1,14 @@
+import {ImarketCodes} from '../interfaces';
+
+const isImarketCodes = (obj: unknown): obj is ImarketCodes => {
+  if (typeof obj !== 'object' || obj === null) return false;
+
+  const objAsRecord = obj as Record<string, unknown>;
+  return (
+    typeof objAsRecord.market === 'string' &&
+    typeof objAsRecord.korean_name === 'string' &&
+    typeof objAsRecord.english_name === 'string'
+  );
+};
+
+export default isImarketCodes;

--- a/src/hooks/useWsOrderbook.ts
+++ b/src/hooks/useWsOrderbook.ts
@@ -17,8 +17,8 @@ import isImarketCodes from '../functions/isImarketCodes';
  */
 function useWsOrderbook(
   targetMarketCodes: ImarketCodes,
-  options: OBOptionsInterface = {},
   onError?: (error: Error) => void,
+  options: OBOptionsInterface = {},
 ) {
   const {throttle_time = 400, debug = false} = options;
   const SOCKET_URL = 'wss://api.upbit.com/websocket/v1';

--- a/src/hooks/useWsOrderbook.ts
+++ b/src/hooks/useWsOrderbook.ts
@@ -1,8 +1,10 @@
-import {IOrderbook, ImarketCodes} from '../interfaces';
+import {IOrderbook, ImarketCodes, OBOptionsInterface} from '../interfaces';
 import {useRef, useState, useCallback, useEffect} from 'react';
 import {throttle} from 'lodash';
 import getLastBuffers from '../functions/getLastBuffers';
 import socketDataEncoder from '../functions/socketDataEncoder';
+
+// extend extend OptionsInterface
 
 /**
  * useWsOrderbook is a custom hook that connects to a WebSocket API
@@ -13,11 +15,11 @@ import socketDataEncoder from '../functions/socketDataEncoder';
  * @returns Object with the WebSocket object, connection status, and real-time orderbook data.
  */
 function useWsOrderbook(
-  targetMarketCodes: ImarketCodes[],
-  options = {throttle_time: 400, debug: false},
+  targetMarketCodes: ImarketCodes,
+  options: OBOptionsInterface = {},
 ) {
+  const {throttle_time = 400, debug = false} = options;
   const SOCKET_URL = 'wss://api.upbit.com/websocket/v1';
-  const {throttle_time} = options;
   const socket = useRef<WebSocket | null>(null);
   const buffer = useRef<IOrderbook[]>([]);
 
@@ -29,7 +31,7 @@ function useWsOrderbook(
       try {
         const lastBuffers = getLastBuffers(
           buffer.current,
-          targetMarketCodes.length,
+          [targetMarketCodes].length,
         );
         lastBuffers && setSocketData(lastBuffers[0]);
         buffer.current = [];
@@ -42,19 +44,13 @@ function useWsOrderbook(
   // socket 세팅
   useEffect(() => {
     try {
-      if (targetMarketCodes.length > 1) {
-        throw new Error(
-          "[Error] | 'Length' of Target Market Codes should be only 'one' in 'orderbook' and 'trade'. you can request only 1 marketcode's data, when you want to get 'orderbook' or 'trade' data.",
-        );
-      }
-
-      if (targetMarketCodes.length > 0 && !socket.current) {
+      if ([targetMarketCodes].length > 0 && !socket.current) {
         socket.current = new WebSocket(SOCKET_URL);
         socket.current.binaryType = 'arraybuffer';
 
         const socketOpenHandler = () => {
           setIsConnected(true);
-          if (options.debug)
+          if (debug)
             console.log(
               '[completed connect] | socket Open Type: ',
               'orderbook',
@@ -64,11 +60,11 @@ function useWsOrderbook(
               {ticket: 'test'},
               {
                 type: 'orderbook',
-                codes: targetMarketCodes.map(code => code.market),
+                codes: [targetMarketCodes.market],
               },
             ];
             socket.current.send(JSON.stringify(sendContent));
-            if (options.debug) console.log('message sending done');
+            if (debug) console.log('message sending done');
           }
         };
 
@@ -76,12 +72,12 @@ function useWsOrderbook(
           setIsConnected(false);
           setSocketData(undefined);
           buffer.current = [];
-          if (options.debug) console.log('connection closed');
+          if (debug) console.log('connection closed');
         };
 
         const socketErrorHandler = (event: Event) => {
           const error = (event as ErrorEvent).error as Error;
-          if (options.debug) console.error('[Error]', error);
+          if (debug) console.error('[Error]', error);
         };
 
         const socketMessageHandler = (evt: MessageEvent<ArrayBuffer>) => {

--- a/src/hooks/useWsTicker.ts
+++ b/src/hooks/useWsTicker.ts
@@ -17,8 +17,8 @@ import isArrayOfImarketCodes from '../functions/isArrayOfImarketCodes';
  */
 function useWsTicker(
   targetMarketCodes: ImarketCodes[],
-  options: TKOptionsInterface = {},
   onError?: (error: Error) => void,
+  options: TKOptionsInterface = {},
 ) {
   const {throttle_time = 400, debug = false} = options;
   const SOCKET_URL = 'wss://api.upbit.com/websocket/v1';

--- a/src/hooks/useWsTicker.ts
+++ b/src/hooks/useWsTicker.ts
@@ -1,4 +1,4 @@
-import {ITicker, ImarketCodes} from '../interfaces';
+import {ITicker, ImarketCodes, TKOptionsInterface} from '../interfaces';
 import {useRef, useState, useCallback, useEffect} from 'react';
 import getLastBuffers from '../functions/getLastBuffers';
 import sortBuffers from '../functions/sortBuffers';
@@ -16,10 +16,10 @@ import updateSocketData from '../functions/updateSocketData';
  */
 function useWsTicker(
   targetMarketCodes: ImarketCodes[],
-  options = {throttle_time: 400, debug: false},
+  options: TKOptionsInterface = {},
 ) {
+  const {throttle_time = 400, debug = false} = options;
   const SOCKET_URL = 'wss://api.upbit.com/websocket/v1';
-  const {throttle_time} = options;
   const socket = useRef<WebSocket | null>(null);
   const buffer = useRef<ITicker[]>([]);
 
@@ -54,7 +54,7 @@ function useWsTicker(
 
         const socketOpenHandler = () => {
           setIsConnected(true);
-          if (options.debug)
+          if (debug)
             console.log('[completed connect] | socket Open Type: ', 'ticker');
           if (socket.current?.readyState == 1) {
             const sendContent = [
@@ -65,7 +65,7 @@ function useWsTicker(
               },
             ];
             socket.current.send(JSON.stringify(sendContent));
-            if (options.debug) console.log('message sending done');
+            if (debug) console.log('message sending done');
           }
         };
 
@@ -74,7 +74,7 @@ function useWsTicker(
           setLoadingBuffer([]);
           setSocketData([]);
           buffer.current = [];
-          if (options.debug) console.log('connection closed');
+          if (debug) console.log('connection closed');
         };
 
         const socketErrorHandler = (event: Event) => {

--- a/src/hooks/useWsTrade.ts
+++ b/src/hooks/useWsTrade.ts
@@ -17,8 +17,8 @@ import isImarketCodes from '../functions/isImarketCodes';
  */
 function useWsTrade(
   targetMarketCodes: ImarketCodes,
-  options: TROptionsInterface = {},
   onError?: (error: Error) => void,
+  options: TROptionsInterface = {},
 ) {
   const {throttle_time = 400, max_length_queue = 100, debug = false} = options;
   const SOCKET_URL = 'wss://api.upbit.com/websocket/v1';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -98,3 +98,15 @@ export interface TradeInterface {
   isConnected: boolean;
   socketData: ITrade[];
 }
+
+export interface OptionsInterface {
+  debug?: boolean;
+}
+
+export interface OBOptionsInterface extends OptionsInterface {
+  throttle_time?: number;
+}
+export interface TROptionsInterface extends OptionsInterface {
+  throttle_time?: number;
+  max_length_queue?: number;
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -106,6 +106,10 @@ export interface OptionsInterface {
 export interface OBOptionsInterface extends OptionsInterface {
   throttle_time?: number;
 }
+export interface TKOptionsInterface extends OptionsInterface {
+  throttle_time?: number;
+}
+
 export interface TROptionsInterface extends OptionsInterface {
   throttle_time?: number;
   max_length_queue?: number;

--- a/test/unit/functions/isArrayOfImarketCodes.test.ts
+++ b/test/unit/functions/isArrayOfImarketCodes.test.ts
@@ -1,0 +1,38 @@
+import isArrayOfImarketCodes from '../../../src/functions/isArrayOfImarketCodes';
+import {ImarketCodes} from '../../../src/interfaces';
+
+describe('isArrayOfImarketCodes', () => {
+  it('should return true for an array of valid ImarketCodes objects', () => {
+    const validMarketCodesArray: ImarketCodes[] = [
+      {market: 'KRW-BTC', korean_name: '비트코인', english_name: 'Bitcoin'},
+      {market: 'KRW-ETH', korean_name: '이더리움', english_name: 'Ethereum'},
+    ];
+
+    expect(isArrayOfImarketCodes(validMarketCodesArray)).toBe(true);
+  });
+
+  it('should return false for an array containing invalid ImarketCodes objects', () => {
+    const invalidMarketCodesArray = [
+      {market: 'KRW-BTC', korean_name: '비트코인', english_name: 'Bitcoin'},
+      {market: 'KRW-ETH', korean_name: '이더리움'}, // missing english_name
+    ];
+
+    expect(isArrayOfImarketCodes(invalidMarketCodesArray)).toBe(false);
+  });
+
+  it('should return false for a non-array value', () => {
+    const notAnArray = {
+      market: 'KRW-BTC',
+      korean_name: '비트코인',
+      english_name: 'Bitcoin',
+    };
+
+    expect(isArrayOfImarketCodes(notAnArray)).toBe(false);
+  });
+
+  it('should return false for an empty array', () => {
+    const emptyArray: unknown[] = [];
+
+    expect(isArrayOfImarketCodes(emptyArray)).toBe(false);
+  });
+});

--- a/test/unit/functions/isImarketCodes.test.ts
+++ b/test/unit/functions/isImarketCodes.test.ts
@@ -1,0 +1,32 @@
+import isImarketCodes from '../../../src/functions/isImarketCodes';
+import {ImarketCodes} from '../../../src/interfaces';
+
+describe('isImarketCodes', () => {
+  it('should return true for valid ImarketCodes objects', () => {
+    const validMarketCode: ImarketCodes = {
+      market: 'KRW-BTC',
+      korean_name: '비트코인',
+      english_name: 'Bitcoin',
+    };
+
+    expect(isImarketCodes(validMarketCode)).toBe(true);
+  });
+
+  it('should return false for invalid objects', () => {
+    const invalidMarketCode = {
+      market: 'KRW-BTC',
+      korean_name: '비트코인',
+      // Missing english_name property
+    };
+
+    expect(isImarketCodes(invalidMarketCode)).toBe(false);
+  });
+
+  it('should return false for non-object values', () => {
+    const nonObjectValues: unknown[] = ['string', 42, true, null, undefined];
+
+    nonObjectValues.forEach(value => {
+      expect(isImarketCodes(value)).toBe(false);
+    });
+  });
+});

--- a/test/unit/hooks/ErrorBoundary.tsx
+++ b/test/unit/hooks/ErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import {useState, useCallback, ReactNode} from 'react';
+
+const ErrorBoundary = ({
+  children,
+  onError,
+}: {
+  children: ReactNode;
+  onError: (error: Error) => void;
+}) => {
+  const [hasError, setHasError] = useState(false);
+
+  const errorBoundaryCallback = useCallback(
+    (error: Error) => {
+      setHasError(true);
+      onError(error);
+    },
+    [onError],
+  );
+
+  if (hasError) {
+    return null;
+  }
+
+  return (
+    <React.Fragment>
+      {React.Children.map(children, child =>
+        React.cloneElement(child as React.ReactElement, {
+          onError: errorBoundaryCallback,
+        }),
+      )}
+    </React.Fragment>
+  );
+};
+
+export default ErrorBoundary;

--- a/test/unit/hooks/useFetchMarketCode.test.tsx
+++ b/test/unit/hooks/useFetchMarketCode.test.tsx
@@ -8,8 +8,10 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+const debugTest = false;
+
 const TestFetchMarketCodeComponent = () => {
-  const {isLoading, marketCodes} = useFetchMarketCode({debug: true});
+  const {isLoading, marketCodes} = useFetchMarketCode({debug: debugTest});
 
   return (
     <div>

--- a/test/unit/hooks/useWsOrderbook.test.tsx
+++ b/test/unit/hooks/useWsOrderbook.test.tsx
@@ -30,10 +30,10 @@ const TestOrderbookComponent = ({
 
   const {isConnected, socketData} = useWsOrderbook(
     marketCode as ImarketCodes,
+    onError,
     {
       debug: debugTest,
     },
-    onError,
   );
 
   return (

--- a/test/unit/hooks/useWsOrderbook.test.tsx
+++ b/test/unit/hooks/useWsOrderbook.test.tsx
@@ -7,14 +7,12 @@ import {render, screen, waitFor} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 const TestOrderbookComponent = () => {
-  const [marketCode, _] = useState([
-    {
-      market: 'KRW-BTC',
-      korean_name: '비트코인',
-      english_name: 'Bitcoin',
-    },
-  ]);
-  const {isConnected, socketData} = useWsOrderbook(marketCode);
+  const [marketCode, _] = useState({
+    market: 'KRW-BTC',
+    korean_name: '비트코인',
+    english_name: 'Bitcoin',
+  });
+  const {isConnected, socketData} = useWsOrderbook(marketCode, {debug: true});
 
   return (
     <div>

--- a/test/unit/hooks/useWsTicker.test.tsx
+++ b/test/unit/hooks/useWsTicker.test.tsx
@@ -1,19 +1,43 @@
 import useWsTicker from '../../../src/hooks/useWsTicker';
 import * as React from 'react';
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 
 import {render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import ErrorBoundary from './ErrorBoundary';
+import {ImarketCodes} from '../../../src/interfaces';
 
-const TestTickerComponentConnection = () => {
-  const [marketCode, _] = useState([
+const debugTest = false;
+
+const TestTickerComponent = ({
+  customMarketCode,
+  onError,
+}: {
+  customMarketCode?: unknown;
+  onError?: (error: Error) => void;
+}) => {
+  const [marketCode, setMarketCode] = useState<unknown>([
     {
       market: 'KRW-BTC',
       korean_name: '비트코인',
       english_name: 'Bitcoin',
     },
   ]);
-  const {isConnected, socketData} = useWsTicker(marketCode, {debug: true});
+
+  useEffect(() => {
+    if (customMarketCode) {
+      console.log('here', customMarketCode);
+      setMarketCode(() => customMarketCode);
+    }
+  }, [customMarketCode]);
+
+  const {isConnected, socketData} = useWsTicker(
+    marketCode as ImarketCodes[],
+    {
+      debug: debugTest,
+    },
+    onError,
+  );
 
   return (
     <div>
@@ -32,9 +56,39 @@ const TestTickerComponentConnection = () => {
 };
 
 describe('useWsTicker hook', () => {
+  // Test invalid targetMarketCodes
+  it('useWsTicker should throw error with invalid targetMarketCodes', () => {
+    const onError: jest.MockedFunction<(error: Error) => void> = jest.fn();
+    const invalidTargetMarketCodes = [
+      {
+        market: 'KRW-BTC',
+        korean_name: '비트코인',
+        english_name: 'Bitcoin',
+      },
+      {
+        market: 'KRW-ETH',
+        korean_name: '이더리움',
+      },
+    ];
+    // Render the TestOrderbookComponent
+    render(
+      <ErrorBoundary onError={onError}>
+        <TestTickerComponent
+          customMarketCode={invalidTargetMarketCodes}
+          onError={onError}
+        />
+      </ErrorBoundary>,
+    );
+
+    expect(onError).toHaveBeenCalled();
+    expect(onError.mock.calls[0][0].message).toBe(
+      'targetMarketCodes does not have the correct interface',
+    );
+  });
+
   it('renders connection status and received socket data', async () => {
-    // Render the TestTickerComponentConnection
-    render(<TestTickerComponentConnection />);
+    // Render the TestTickerComponent
+    render(<TestTickerComponent />);
 
     // Check if the connection status is displayed
     const connectionStatus = screen.getByText(/Connected|Not Connected/i);

--- a/test/unit/hooks/useWsTicker.test.tsx
+++ b/test/unit/hooks/useWsTicker.test.tsx
@@ -13,7 +13,7 @@ const TestTickerComponentConnection = () => {
       english_name: 'Bitcoin',
     },
   ]);
-  const {isConnected, socketData} = useWsTicker(marketCode);
+  const {isConnected, socketData} = useWsTicker(marketCode, {debug: true});
 
   return (
     <div>

--- a/test/unit/hooks/useWsTicker.test.tsx
+++ b/test/unit/hooks/useWsTicker.test.tsx
@@ -33,10 +33,10 @@ const TestTickerComponent = ({
 
   const {isConnected, socketData} = useWsTicker(
     marketCode as ImarketCodes[],
+    onError,
     {
       debug: debugTest,
     },
-    onError,
   );
 
   return (

--- a/test/unit/hooks/useWsTrade.test.tsx
+++ b/test/unit/hooks/useWsTrade.test.tsx
@@ -5,14 +5,38 @@ import {useState} from 'react';
 
 import {render, screen, waitFor} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import {useEffect} from 'react';
+import {ImarketCodes} from '../../../src/interfaces';
+import ErrorBoundary from './ErrorBoundary';
 
-const TestTradeComponent = () => {
-  const [marketCode, _] = useState({
+const debugTest = false;
+
+const TestTradeComponent = ({
+  customMarketCode,
+  onError,
+}: {
+  customMarketCode?: unknown;
+  onError?: (error: Error) => void;
+}) => {
+  const [marketCode, setMarketCode] = useState<unknown>({
     market: 'KRW-BTC',
     korean_name: '비트코인',
     english_name: 'Bitcoin',
   });
-  const {isConnected, socketData} = useWsTrade(marketCode, {debug: true});
+
+  useEffect(() => {
+    if (customMarketCode) {
+      setMarketCode(() => customMarketCode);
+    }
+  }, [customMarketCode]);
+
+  const {isConnected, socketData} = useWsTrade(
+    marketCode as ImarketCodes,
+    {
+      debug: debugTest,
+    },
+    onError,
+  );
 
   return (
     <div>
@@ -31,6 +55,29 @@ const TestTradeComponent = () => {
 };
 
 describe('useWsTrade hook', () => {
+  // Test invalid targetMarketCodes
+  it('useWsTrade should throw error with invalid targetMarketCodes', () => {
+    const onError: jest.MockedFunction<(error: Error) => void> = jest.fn();
+    const invalidTargetMarketCodes = {
+      market: 'test_market',
+      korean_name: 'test_korean',
+    };
+    // Render the TestTradeComponent
+    render(
+      <ErrorBoundary onError={onError}>
+        <TestTradeComponent
+          customMarketCode={invalidTargetMarketCodes}
+          onError={onError}
+        />
+      </ErrorBoundary>,
+    );
+
+    expect(onError).toHaveBeenCalled();
+    expect(onError.mock.calls[0][0].message).toBe(
+      'targetMarketCodes does not have the correct interface',
+    );
+  });
+
   it('renders connection status and received socket data', async () => {
     // Render the TestTradeComponent
     render(<TestTradeComponent />);

--- a/test/unit/hooks/useWsTrade.test.tsx
+++ b/test/unit/hooks/useWsTrade.test.tsx
@@ -32,10 +32,10 @@ const TestTradeComponent = ({
 
   const {isConnected, socketData} = useWsTrade(
     marketCode as ImarketCodes,
+    onError,
     {
       debug: debugTest,
     },
-    onError,
   );
 
   return (

--- a/test/unit/hooks/useWsTrade.test.tsx
+++ b/test/unit/hooks/useWsTrade.test.tsx
@@ -12,7 +12,7 @@ const TestTradeComponent = () => {
     korean_name: '비트코인',
     english_name: 'Bitcoin',
   });
-  const {isConnected, socketData} = useWsTrade(marketCode);
+  const {isConnected, socketData} = useWsTrade(marketCode, {debug: true});
 
   return (
     <div>

--- a/test/unit/hooks/useWsTrade.test.tsx
+++ b/test/unit/hooks/useWsTrade.test.tsx
@@ -7,13 +7,11 @@ import {render, screen, waitFor} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 const TestTradeComponent = () => {
-  const [marketCode, _] = useState([
-    {
-      market: 'KRW-BTC',
-      korean_name: '비트코인',
-      english_name: 'Bitcoin',
-    },
-  ]);
+  const [marketCode, _] = useState({
+    market: 'KRW-BTC',
+    korean_name: '비트코인',
+    english_name: 'Bitcoin',
+  });
   const {isConnected, socketData} = useWsTrade(marketCode);
 
   return (


### PR DESCRIPTION
- target market code의 invalid 검사
- 에러 처리를 위한 onError prop 추가
- target market code가 invalid할 때를 가정한 테스트 코드 추가 (with ErrorBoundary)